### PR TITLE
Add 'TEMP_DEPTH_HALFMETER_MEAN' to saildrones list

### DIFF
--- a/crocolakeloader/params.py
+++ b/crocolakeloader/params.py
@@ -690,6 +690,7 @@ params["Saildrones"] = [
     'longitude',
     'time',
     'TEMP_SBE37_MEAN',
+    'TEMP_DEPTH_HALFMETER_MEAN',
     'SAL_SBE37_MEAN',
     'O2_CONC_SBE37_MEAN',
     'CHLOR_WETLABS_MEAN',

--- a/crocolakeloader/params.py
+++ b/crocolakeloader/params.py
@@ -711,7 +711,6 @@ params["Saildrones2CROCOLAKE"] = {
     'latitude': 'LATITUDE',
     'longitude': 'LONGITUDE',
     'time': 'JULD',
-    'TEMP_SBE37_MEAN': 'TEMP',
     'SAL_SBE37_MEAN': 'PSAL',
     'O2_CONC_SBE37_MEAN': 'DOXY',
     'CHLOR_WETLABS_MEAN': 'CHLA',


### PR DESCRIPTION
### Summary
Add 'TEMP_DEPTH_HALFMETER_MEAN' to the list of recognized parameters.

### Context
This change is required to combine multi temperature sources into TEMP column. introduced in [PR #6](https://github.com/boom-lab/crocolaketools-public/pull/6/) in the crocolaketools repo.

**Please review together with the main PR to ensure compatibility.**