### PR TITLE
Raise error when installing with Python 3.13

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,21 @@
+name: crocolakeloader
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.9,<3.13
+  - pip
+  - dask>=2024.7.1
+  - distributed>=2024.7.1
+  - numpy==1.26.4
+  - pandas==2.2.2
+  - psutil==5.9.8
+  - pyarrow==16.1.0
+  - scipy==1.13.1
+  - setuptools==69.5.1
+  - urllib3==1.26.6
+  - xarray
+  - gsw==3.6.19
+  - bokeh==3.9.1
+  - pytest
+  - cartopy
+  - matplotlib

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,13 @@ setup(
     long_description=long_description,
     author='Enrico Milanese',
     author_email='enrico.milanese@whoi.edu',
+    python_requires='>=3.9,<3.13',
+    classifiers=[
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+    ],
     packages=find_packages(),
     install_requires=parse_requirements('requirements.txt'),
     entry_points={


### PR DESCRIPTION
pip install fails with Python 3.13 (#12 ). this fix does not solve the issue, but raises an error if the user installs the package with an incompatible version of Python

it also adds environment.yml for conda